### PR TITLE
Node.js AWS Task #7 Solution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ node_modules
 package-lock.json
 
 .idea
+
+*/.env.local

--- a/authorization-service/.gitignore
+++ b/authorization-service/.gitignore
@@ -1,0 +1,11 @@
+# package directories
+node_modules
+jspm_packages
+
+# Serverless directories
+.serverless
+
+# Webpack directories
+.webpack
+
+.env.local

--- a/authorization-service/.vscode/launch.json
+++ b/authorization-service/.vscode/launch.json
@@ -1,0 +1,14 @@
+{
+  "configurations": [
+    {
+      "name": "Lambda",
+      "type": "node",
+      "request": "launch",
+      "runtimeArgs": ["--inspect", "--debug-port=9229"],
+      "program": "${workspaceFolder}/node_modules/serverless/bin/serverless",
+      "args": ["offline"],
+      "port": 9229,
+      "console": "integratedTerminal"
+    }
+  ]
+}

--- a/authorization-service/config.ts
+++ b/authorization-service/config.ts
@@ -1,0 +1,2 @@
+export const USERNAME = process.env.USERNAME;
+export const PASSWORD = process.env.PASSWORD;

--- a/authorization-service/config.ts
+++ b/authorization-service/config.ts
@@ -1,2 +1,2 @@
-export const USERNAME = process.env.USERNAME;
-export const PASSWORD = process.env.PASSWORD;
+export const IMPORT_USERNAME = process.env.IMPORT_USERNAME;
+export const IMPORT_PASSWORD = process.env.IMPORT_PASSWORD;

--- a/authorization-service/handler.ts
+++ b/authorization-service/handler.ts
@@ -1,0 +1,3 @@
+import {basicAuthorizeHandler} from './handlers/basicAutorize';
+
+export {basicAuthorizeHandler};

--- a/authorization-service/handlers/basicAutorize.ts
+++ b/authorization-service/handlers/basicAutorize.ts
@@ -1,0 +1,62 @@
+import {APIGatewayAuthorizerEvent, APIGatewayAuthorizerHandler, APIGatewayAuthorizerResult} from 'aws-lambda';
+import {PASSWORD, USERNAME} from '../config';
+
+export const basicAuthorize = async (event: APIGatewayAuthorizerEvent): Promise<APIGatewayAuthorizerResult> => {
+  console.log('event: ', event);
+
+  if (event.type !== 'TOKEN') {
+    return Promise.reject('Unauthorized');
+  }
+
+  try {
+    const resource = event.methodArn;
+
+    const {authorizationToken} = event;
+
+    const [authType, encodedCreds] = authorizationToken.split(' ');
+
+    if (authType !== 'Basic') {
+      return Promise.reject('Unauthorized');
+    }
+
+    const [username, password] = Buffer.from(encodedCreds, 'base64')
+      .toString('utf-8')
+      .split(':');
+
+    let effect = 'Allow';
+
+    if (
+      username !== USERNAME ||
+      password !== PASSWORD
+    ) {
+      effect = 'Deny';
+    }
+
+    const policy = generatePolicy(encodedCreds, effect, resource);
+
+    return Promise.resolve(policy);
+  } catch (err) {
+    console.log('ERROR: ', err);
+    return Promise.reject('Unauthorized');
+  }
+};
+
+function generatePolicy(principalId, effect, resource): APIGatewayAuthorizerResult {
+  return {
+    principalId,
+    policyDocument: {
+      Version: '2012-10-17',
+      Statement: [
+        {
+          Action: 'execute-api:Invoke',
+          Effect: effect,
+          Resource: resource
+        }
+      ]
+    }
+  };
+}
+
+export const basicAuthorizeHandler: APIGatewayAuthorizerHandler = async (event: APIGatewayAuthorizerEvent) => {
+  return basicAuthorize(event);
+};

--- a/authorization-service/handlers/basicAutorize.ts
+++ b/authorization-service/handlers/basicAutorize.ts
@@ -1,5 +1,5 @@
 import {APIGatewayAuthorizerEvent, APIGatewayAuthorizerHandler, APIGatewayAuthorizerResult} from 'aws-lambda';
-import {PASSWORD, USERNAME} from '../config';
+import {IMPORT_PASSWORD, IMPORT_USERNAME} from '../config';
 
 export const basicAuthorize = async (event: APIGatewayAuthorizerEvent): Promise<APIGatewayAuthorizerResult> => {
   console.log('event: ', event);
@@ -25,9 +25,12 @@ export const basicAuthorize = async (event: APIGatewayAuthorizerEvent): Promise<
 
     let effect = 'Allow';
 
+    console.log('DECODED USERNAME: ', username);
+    console.log('DECODED PASSWORD: ', password);
+
     if (
-      username !== USERNAME ||
-      password !== PASSWORD
+      username !== IMPORT_USERNAME ||
+      password !== IMPORT_PASSWORD
     ) {
       effect = 'Deny';
     }

--- a/authorization-service/handlers/basicAutorize.ts
+++ b/authorization-service/handlers/basicAutorize.ts
@@ -15,25 +15,30 @@ export const basicAuthorize = async (event: APIGatewayAuthorizerEvent): Promise<
 
     const [authType, encodedCreds] = authorizationToken.split(' ');
 
-    if (authType !== 'Basic') {
-      return Promise.reject('Unauthorized');
-    }
-
-    const [username, password] = Buffer.from(encodedCreds, 'base64')
-      .toString('utf-8')
-      .split(':');
+    console.log('AUTH TYPE: ', authType);
+    console.log('ENCODED CREDENTIALS: ', encodedCreds);
 
     let effect = 'Allow';
+    let username = '';
+    let password = '';
+
+    if (authType && encodedCreds) {
+      [username, password] = Buffer.from(encodedCreds, 'base64')
+        .toString('utf-8')
+        .split(':');
+
+      if (
+        username !== IMPORT_USERNAME ||
+        password !== IMPORT_PASSWORD
+      ) {
+        effect = 'Deny';
+      }
+    } else {
+      effect = 'Deny';
+    }
 
     console.log('DECODED USERNAME: ', username);
     console.log('DECODED PASSWORD: ', password);
-
-    if (
-      username !== IMPORT_USERNAME ||
-      password !== IMPORT_PASSWORD
-    ) {
-      effect = 'Deny';
-    }
 
     const policy = generatePolicy(encodedCreds, effect, resource);
 

--- a/authorization-service/package.json
+++ b/authorization-service/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "authorization-service",
+  "version": "1.0.0",
+  "description": "Serverless webpack example using Typescript",
+  "main": "handler.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "dependencies": {
+    "source-map-support": "^0.5.10",
+    "serverless-dotenv-plugin": "^3.1.0",
+    "serverless-pseudo-parameters": "^2.5.0"
+  },
+  "devDependencies": {
+    "@types/aws-lambda": "^8.10.17",
+    "@types/node": "^10.12.18",
+    "@types/serverless": "^1.72.5",
+    "fork-ts-checker-webpack-plugin": "^3.0.1",
+    "serverless-webpack": "^5.2.0",
+    "ts-loader": "^5.3.3",
+    "ts-node": "^8.10.2",
+    "typescript": "^3.2.4",
+    "webpack": "^4.29.0",
+    "webpack-node-externals": "^1.7.2"
+  },
+  "author": "The serverless webpack authors (https://github.com/elastic-coders/serverless-webpack)",
+  "license": "MIT"
+}

--- a/authorization-service/serverless.ts
+++ b/authorization-service/serverless.ts
@@ -1,0 +1,47 @@
+import type {Serverless} from 'serverless/aws';
+
+const serverlessConfiguration: Serverless = {
+  service: {
+    name: 'authorization-service'
+  },
+  frameworkVersion: '2',
+  custom: {
+    webpack: {
+      webpackConfig: './webpack.config.js',
+      includeModules: true
+    }
+  },
+  plugins: [
+    'serverless-webpack',
+    'serverless-dotenv-plugin'
+  ],
+  provider: {
+    name: 'aws',
+    runtime: 'nodejs12.x',
+    stage: 'dev',
+    region: 'eu-west-1',
+    apiGateway: {
+      minimumCompressionSize: 1024
+    },
+    environment: {
+      AWS_NODEJS_CONNECTION_REUSE_ENABLED: '1'
+    }
+  },
+  functions: {
+    basicAuthorizer: {
+      handler: 'handler.basicAuthorizeHandler'
+    }
+  },
+  resources: {
+    Resources: {},
+    Outputs: {
+      basicAuthorizerArn: {
+        Value: {
+          'Fn::GetAtt': ['BasicAuthorizerLambdaFunction', 'Arn']
+        }
+      }
+    }
+  }
+};
+
+module.exports = serverlessConfiguration;

--- a/authorization-service/tsconfig.json
+++ b/authorization-service/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "lib": ["es2017"],
+    "removeComments": true,
+    "moduleResolution": "node",
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "sourceMap": true,
+    "target": "es2017",
+    "outDir": "lib"
+  },
+  "include": ["./**/*.ts"],
+  "exclude": [
+    "node_modules/**/*",
+    ".serverless/**/*",
+    ".webpack/**/*",
+    "_warmup/**/*",
+    ".vscode/**/*"
+  ]
+}

--- a/authorization-service/webpack.config.js
+++ b/authorization-service/webpack.config.js
@@ -1,0 +1,51 @@
+const path = require('path');
+const slsw = require('serverless-webpack');
+const nodeExternals = require('webpack-node-externals');
+const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin');
+
+module.exports = {
+  context: __dirname,
+  mode: slsw.lib.webpack.isLocal ? 'development' : 'production',
+  entry: slsw.lib.entries,
+  devtool: slsw.lib.webpack.isLocal ? 'cheap-module-eval-source-map' : 'source-map',
+  resolve: {
+    extensions: ['.mjs', '.json', '.ts'],
+    symlinks: false,
+    cacheWithContext: false,
+  },
+  output: {
+    libraryTarget: 'commonjs',
+    path: path.join(__dirname, '.webpack'),
+    filename: '[name].js',
+  },
+  target: 'node',
+  externals: [nodeExternals()],
+  module: {
+    rules: [
+      // all files with a `.ts` or `.tsx` extension will be handled by `ts-loader`
+      {
+        test: /\.(tsx?)$/,
+        loader: 'ts-loader',
+        exclude: [
+          [
+            path.resolve(__dirname, 'node_modules'),
+            path.resolve(__dirname, '.serverless'),
+            path.resolve(__dirname, '.webpack'),
+          ],
+        ],
+        options: {
+          transpileOnly: true,
+          experimentalWatchApi: true,
+        },
+      },
+    ],
+  },
+  plugins: [
+    // new ForkTsCheckerWebpackPlugin({
+    //   eslint: true,
+    //   eslintOptions: {
+    //     cache: true
+    //   }
+    // })
+  ],
+};

--- a/import-service/serverless.ts
+++ b/import-service/serverless.ts
@@ -71,6 +71,70 @@ const serverlessConfiguration: Serverless = {
             ]
           }
         }
+      },
+      GatewayResponseDEFAULT4XX: {
+        Type: 'AWS::ApiGateway::GatewayResponse',
+        Properties: {
+          ResponseParameters: {
+            'gatewayresponse.header.Access-Control-Allow-Origin': '\'*\'',
+            'gatewayresponse.header.Access-Control-Allow-Headers': '\'*\''
+          },
+          ResponseType: 'DEFAULT_4XX',
+          RestApiId: {
+            Ref: 'ApiGatewayRestApi'
+          },
+          ResponseTemplates: {
+            'application/json': '{"data": $context.error.messageString}'
+          }
+        }
+      },
+      GatewayResponseAccessDenied: {
+        Type: 'AWS::ApiGateway::GatewayResponse',
+        Properties: {
+          ResponseParameters: {
+            'gatewayresponse.header.Access-Control-Allow-Origin': '\'*\'',
+            'gatewayresponse.header.Access-Control-Allow-Headers': '\'*\''
+          },
+          ResponseType: 'ACCESS_DENIED',
+          ResponseTemplates: {
+            'application/json': '{"message": $context.error.messageString}'
+          },
+          RestApiId: {
+            Ref: 'ApiGatewayRestApi'
+          }
+        }
+      },
+      GatewayResponseUnauthorized: {
+        Type: 'AWS::ApiGateway::GatewayResponse',
+        Properties: {
+          ResponseParameters: {
+            'gatewayresponse.header.Access-Control-Allow-Origin': '\'*\'',
+            'gatewayresponse.header.Access-Control-Allow-Headers': '\'*\''
+          },
+          ResponseType: 'UNAUTHORIZED',
+          ResponseTemplates: {
+            'application/json': '{"message": $context.error.messageString}'
+          },
+          RestApiId: {
+            Ref: 'ApiGatewayRestApi'
+          }
+        }
+      },
+      GatewayResponseDEFAULT5XX: {
+        Type: 'AWS::ApiGateway::GatewayResponse',
+        Properties: {
+          ResponseParameters: {
+            'gatewayresponse.header.Access-Control-Allow-Origin': '\'*\'',
+            'gatewayresponse.header.Access-Control-Allow-Headers': '\'*\''
+          },
+          ResponseType: 'DEFAULT_5XX',
+          ResponseTemplates: {
+            'application/json': '{"data": $context.error.messageString}'
+          },
+          RestApiId: {
+            Ref: 'ApiGatewayRestApi'
+          }
+        }
       }
     }
   },
@@ -83,6 +147,13 @@ const serverlessConfiguration: Serverless = {
             method: 'get',
             path: 'import',
             cors: true,
+            authorizer: {
+              name: 'basicAuthorizer',
+              arn: '${cf:authorization-service-${self:provider.stage}.basicAuthorizerArn}',
+              resultTtlInSeconds: 0,
+              identitySource: 'method.request.header.Authorization',
+              type: 'token'
+            },
             request: {
               parameters: {
                 querystrings: {


### PR DESCRIPTION
**TASK 7.1 ✅**
**TASK 7.2 ✅**
**TASK 7.3 ✅**

## Evaluation criteria ✅

Provide your reviewers with the link to the repo, client application and URLs to execute the /import path of the import-service

**Integrated FE link**
https://d3ehhvbc9pzoid.cloudfront.net/admin/products
> PR for alerts: https://github.com/OHalahan/nodejs-aws-fe/pull/4/files
> PR for local storage: https://github.com/OHalahan/nodejs-aws-fe/pull/5/files

**Import lambda link:**
https://m4vi868ne8.execute-api.eu-west-1.amazonaws.com/dev/import?name=products.csv

1 - authorization-service is added to the repo, has correct basicAuthorizer lambda and correct serverless.yaml file ✅
3 - import-service serverless.yaml file has authorizer configuration for the importProductsFile lambda. Request to the ✅ importProductsFile lambda should work only with correct authorization_token being decoded and checked by basicAuthorizer lambda. Response should be in 403 HTTP status if access is denied for this user (invalid authorization_token) and in 401 HTTP status if Authorization header is not provided. ✅
5 - update client application to send Authorization: Basic authorization_token header on import. Client should get authorization_token value from browser localStorage https://developer.mozilla.org/ru/docs/Web/API/Window/localStorage authorization_token = localStorage.getItem('authorization_token') ✅

> FE app sets correct authorization token by default: 
> **ohalahan:TEST_PASSWORD => Basic b2hhbGFoYW46VEVTVF9QQVNTV09SRA==**
> go to **Dev tools -> Application -> Local Storage** and change token to check **403** response
> ![image](https://user-images.githubusercontent.com/16606092/100549508-ef2cf800-327b-11eb-9171-b83e49b866f8.png)


## Additional (optional) tasks ✅
+1 - Client application should display alerts for the responses in 401 and 403 HTTP statuses. This behavior should be added to the nodejs-aws-fe-main/src/index.tsx file ✅

**No Authorization header provided (401):**
![image](https://user-images.githubusercontent.com/16606092/100548255-12ec4000-3274-11eb-93d1-9dae225f8c71.png)

**Incorrect credentials (403):**
![image](https://user-images.githubusercontent.com/16606092/100548272-2dbeb480-3274-11eb-929e-ce2ef7ac5e08.png)